### PR TITLE
BugFix/ Exception Handling on Background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Socket Timeout Exceptions and GaiExceptions on unsubscribed RxSingles
+
 ## [1.2.8] - 2019-02-05
 
 ### Added

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,8 +63,8 @@ android {
 
 dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-  implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9-native-mt'
-  implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-rx2:1.3.9-native-mt'
+  implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9'
+  implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-rx2:1.3.9'
   implementation 'androidx.appcompat:appcompat:1.3.0-alpha02'
   implementation 'androidx.core:core-ktx:1.3.1'
   implementation 'androidx.preference:preference-ktx:1.1.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,11 +10,11 @@ repositories {
 apply from: 'jacoco.gradle'
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
   defaultConfig {
     applicationId 'app.envelop'
     minSdkVersion 21
-    targetSdkVersion 29
+    targetSdkVersion 30
     versionCode 26
     versionName '1.2.8'
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -52,21 +52,29 @@ android {
   packagingOptions {
     exclude 'META-INF/*'
   }
+  compileOptions {
+    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_1_8
+  }
+  kotlinOptions {
+    jvmTarget = JavaVersion.VERSION_1_8
+  }
 }
 
 dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-  implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.3'
-  implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-rx2:1.3.3'
-  implementation 'androidx.appcompat:appcompat:1.2.0-alpha02'
-  implementation 'androidx.core:core-ktx:1.1.0'
-  implementation 'androidx.preference:preference-ktx:1.1.0'
-  implementation 'com.google.android.material:material:1.2.0-alpha04'
+  implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9-native-mt'
+  implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-rx2:1.3.9-native-mt'
+  implementation 'androidx.appcompat:appcompat:1.3.0-alpha02'
+  implementation 'androidx.core:core-ktx:1.3.1'
+  implementation 'androidx.preference:preference-ktx:1.1.1'
+  implementation 'com.google.android.material:material:1.3.0-alpha02'
 
   // Architecture Components
   implementation 'androidx.lifecycle:lifecycle-viewmodel:2.2.0'
   implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
-  kapt 'androidx.lifecycle:lifecycle-compiler:2.2.0'
+  implementation 'androidx.lifecycle:lifecycle-common-java8:2.2.0'
+
 
   // Logging
   implementation 'com.jakewharton.timber:timber:4.7.1'
@@ -78,17 +86,17 @@ dependencies {
   implementation 'com.github.blockstack:blockstack-android:0.5.0'
 
   // Dependency Injection
-  implementation 'com.google.dagger:dagger:2.26'
-  kapt 'com.google.dagger:dagger-compiler:2.26'
+  implementation 'com.google.dagger:dagger:2.28.3'
+  kapt 'com.google.dagger:dagger-compiler:2.28.3'
 
   // Database ORM
-  def room_version = '2.2.3'
+  def room_version = '2.2.5'
   implementation "androidx.room:room-runtime:$room_version"
   implementation "androidx.room:room-rxjava2:$room_version"
   kapt "androidx.room:room-compiler:$room_version"
 
   // Rx
-  implementation 'io.reactivex.rxjava2:rxjava:2.2.17'
+  implementation 'io.reactivex.rxjava2:rxjava:2.2.19'
   implementation 'io.reactivex.rxjava2:rxkotlin:2.4.0'
   implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
   implementation 'com.trello.rxlifecycle3:rxlifecycle-android-lifecycle-kotlin:3.1.0'
@@ -100,9 +108,8 @@ dependencies {
   implementation "com.jakewharton.rxbinding3:rxbinding-swiperefreshlayout:$rxbinding_version"
 
   // Lists
-  // The latest Epoxy version is causing the app to crash
-  implementation 'com.airbnb.android:epoxy:3.9.0'
-  kapt 'com.airbnb.android:epoxy-processor:3.9.0'
+  implementation 'com.airbnb.android:epoxy:3.11.0'
+  kapt 'com.airbnb.android:epoxy-processor:3.11.0'
 
   // Encryption
   implementation 'com.madgag.spongycastle:bcpkix-jdk15on:1.58.0.0'
@@ -110,11 +117,11 @@ dependencies {
 
   // Testing
   testImplementation 'junit:junit:4.13'
-  testImplementation 'org.mockito:mockito-inline:3.2.4'
+  testImplementation 'org.mockito:mockito-inline:3.5.9'
   testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
-  androidTestImplementation 'androidx.test:runner:1.2.0'
-  androidTestImplementation 'androidx.test:rules:1.2.0'
-  androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-  androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-  androidTestImplementation 'androidx.test.espresso:espresso-intents:3.2.0'
+  androidTestImplementation 'androidx.test:runner:1.3.0'
+  androidTestImplementation 'androidx.test:rules:1.3.0'
+  androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+  androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+  androidTestImplementation 'androidx.test.espresso:espresso-intents:3.3.0'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,7 +16,7 @@ android {
     minSdkVersion 21
     targetSdkVersion 30
     versionCode 26
-    versionName '1.2.8'
+    versionName '1.2.9'
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
   buildTypes {

--- a/app/src/main/java/app/envelop/common/Operation.kt
+++ b/app/src/main/java/app/envelop/common/Operation.kt
@@ -5,7 +5,7 @@ import io.reactivex.Observable
 import io.reactivex.Single
 import io.reactivex.SingleSource
 
-class Operation<out T>(
+data class Operation<out T>(
   private val result: T? = null,
   private val throwable: Throwable? = null
 ) {

--- a/app/src/main/java/app/envelop/common/rx/RxSingleToOperation.kt
+++ b/app/src/main/java/app/envelop/common/rx/RxSingleToOperation.kt
@@ -11,8 +11,6 @@ import kotlin.coroutines.ContinuationInterceptor
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 
-
-
 /**
  * Creates cold [single][Single] that will run a given [block] in a coroutine and emits its result wrapped in [Operation]
  * The Value is wrapped so it can handle Exceptions even when those are launch after unsubscribing avoiding of propagation

--- a/app/src/main/java/app/envelop/common/rx/RxSingleToOperation.kt
+++ b/app/src/main/java/app/envelop/common/rx/RxSingleToOperation.kt
@@ -1,0 +1,39 @@
+package app.envelop.common.rx
+
+import app.envelop.common.Operation
+import io.reactivex.Single
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.rx2.rxSingle
+import java.lang.Exception
+import kotlin.coroutines.ContinuationInterceptor
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+
+
+/**
+ * Creates cold [single][Single] that will run a given [block] in a coroutine and emits its result wrapped in [Operation]
+ * The Value is wrapped so it can handle Exceptions even when those are launch after unsubscribing avoiding of propagation
+ * Every time the returned observable is subscribed, it starts a new coroutine.
+ * Unsubscribing cancels running coroutine.
+ * Coroutine context can be specified with [context] argument.
+ * If the context does not have any dispatcher nor any other [ContinuationInterceptor], then [Dispatchers.Default] is used.
+ * Method throws [IllegalArgumentException] if provided [context] contains a [Job] instance.
+ */
+public fun <T : Any> rxSingleToOperation(
+  context: CoroutineContext = EmptyCoroutineContext,
+  block: suspend CoroutineScope.() -> T
+):  Single<Operation<T>> {
+  require(context[Job] === null) { "Single context cannot contain job in it." +
+    "Its lifecycle should be managed via Disposable handle. Had $context" }
+
+   return rxSingle(context) {
+     try {
+       Operation.success(block.invoke(this))
+     } catch (e:Exception) {
+       return@rxSingle Operation.error<T>(e)
+     }
+   }
+}

--- a/app/src/main/java/app/envelop/common/rx/RxSingleToOperation.kt
+++ b/app/src/main/java/app/envelop/common/rx/RxSingleToOperation.kt
@@ -26,9 +26,6 @@ public fun <T : Any> rxSingleToOperation(
   context: CoroutineContext = EmptyCoroutineContext,
   block: suspend CoroutineScope.() -> T
 ):  Single<Operation<T>> {
-  require(context[Job] === null) { "Single context cannot contain job in it." +
-    "Its lifecycle should be managed via Disposable handle. Had $context" }
-
    return rxSingle(context) {
      try {
        Operation.success(block.invoke(this))

--- a/app/src/main/java/app/envelop/data/repositories/RemoteRepository.kt
+++ b/app/src/main/java/app/envelop/data/repositories/RemoteRepository.kt
@@ -1,10 +1,13 @@
 package app.envelop.data.repositories
 
+import app.envelop.common.Operation
 import app.envelop.common.Optional
 import app.envelop.common.mapIfSuccessful
 import app.envelop.common.rx.observeOnUI
+import app.envelop.common.rx.rxSingleToOperation
 import app.envelop.common.toOperation
 import com.google.gson.Gson
+import io.reactivex.Single
 import kotlinx.coroutines.rx2.rxSingle
 import org.blockstack.android.sdk.BlockstackSession
 import org.blockstack.android.sdk.model.DeleteFileOptions
@@ -23,7 +26,7 @@ class RemoteRepository
 
   private val blockstack by lazy { blockstackProvider.get() }
 
-  fun <T : Any> getJson(fileName: String, klass: KClass<T>, encrypted: Boolean) =
+  fun <T : Any> getJson(fileName: String, klass: KClass<T>, encrypted: Boolean): Single<Operation<Optional<T>>> =
     rxSingle {
       val result = blockstack.getFile(fileName, GetFileOptions(decrypt = encrypted))
       if (!result.hasErrors) {
@@ -39,7 +42,7 @@ class RemoteRepository
     }.toOperation()
 
   fun uploadByteArray(url: String, data: ByteArray, encrypted: Boolean) =
-    rxSingle {
+    rxSingleToOperation {
       val result = blockstack.putFile(
         url,
         data,
@@ -48,10 +51,10 @@ class RemoteRepository
       if (!result.hasValue) {
         throw UploadError("Error uploading ${url}: ${result.error}")
       }
-    }.toOperation()
+    }
 
   fun <T : Any> uploadJson(fileName: String, content: T, encrypted: Boolean) =
-    rxSingle {
+    rxSingleToOperation {
       val result = blockstack.putFile(
         fileName,
         gson.toJson(content),
@@ -62,26 +65,26 @@ class RemoteRepository
       } else {
         throw UploadError("Error uploading $fileName: ${result.error}")
       }
-    }.toOperation()
+    }
 
   fun deleteFile(fileName: String) =
-    rxSingle {
+    rxSingleToOperation {
       val it = blockstack.deleteFile(fileName, DeleteFileOptions())
       if (it.hasErrors && it.error?.message?.startsWith("FileNotFound") != true) {
         Timber.w(it.error?.toString())
         throw DeleteError(it.error?.toString())
       }
-    }.toOperation()
+    }
 
   private fun getFilesList() =
-    rxSingle {
+    rxSingleToOperation {
       val list = mutableListOf<String>()
       blockstack.listFiles { result ->
         result.value?.let { list.add(it) }
         true
       }
       list
-    }.toOperation()
+    }
 
   fun getFilesList(prefix: String) =
     getFilesList()

--- a/app/src/main/java/app/envelop/data/repositories/RemoteRepository.kt
+++ b/app/src/main/java/app/envelop/data/repositories/RemoteRepository.kt
@@ -27,7 +27,7 @@ class RemoteRepository
   private val blockstack by lazy { blockstackProvider.get() }
 
   fun <T : Any> getJson(fileName: String, klass: KClass<T>, encrypted: Boolean): Single<Operation<Optional<T>>> =
-    rxSingle {
+    rxSingleToOperation {
       val result = blockstack.getFile(fileName, GetFileOptions(decrypt = encrypted))
       if (!result.hasErrors) {
         Optional.create(
@@ -39,7 +39,7 @@ class RemoteRepository
         Timber.w(result.error?.toString())
         throw GetError("Error getting $fileName: ${result.error}")
       }
-    }.toOperation()
+    }
 
   fun uploadByteArray(url: String, data: ByteArray, encrypted: Boolean) =
     rxSingleToOperation {

--- a/app/src/main/java/app/envelop/domain/LoginService.kt
+++ b/app/src/main/java/app/envelop/domain/LoginService.kt
@@ -52,7 +52,8 @@ class LoginService
 
   private fun UserData?.isComplete() =
     this?.let {
-      !it.json.optString("username").isNullOrBlank()
+      val username = it.json.optString("username")
+      (!username.isNullOrBlank() && username != "null")
     } ?: false
 
   private fun UserData.toUser() =

--- a/app/src/main/java/app/envelop/domain/LoginService.kt
+++ b/app/src/main/java/app/envelop/domain/LoginService.kt
@@ -3,6 +3,7 @@ package app.envelop.domain
 import android.app.Activity
 import app.envelop.common.Operation
 import app.envelop.common.di.PerActivity
+import app.envelop.common.rx.rxSingleToOperation
 import app.envelop.common.toOperation
 import app.envelop.data.models.Profile
 import app.envelop.data.models.User
@@ -25,9 +26,9 @@ class LoginService
 ) {
 
   fun login() =
-    rxSingle {
+    rxSingleToOperation {
       blockstackSignInProvider.get().redirectUserToSignIn(activity)
-    }.toOperation()
+    }
 
   fun finishLogin(response: String?): Single<Operation<Unit>> {
     if (response == null) {

--- a/app/src/main/java/app/envelop/ui/BaseActivity.kt
+++ b/app/src/main/java/app/envelop/ui/BaseActivity.kt
@@ -25,6 +25,7 @@ abstract class BaseActivity : AppCompatActivity() {
     window.setSystemBarsStyle(this)
   }
 
+  @Suppress("DEPRECATION")
   override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
     super.onActivityResult(requestCode, resultCode, data)
     results.onNext(ActivityResult(requestCode, resultCode, data))

--- a/app/src/main/java/app/envelop/ui/common/Insets.kt
+++ b/app/src/main/java/app/envelop/ui/common/Insets.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package app.envelop.ui.common
 
 import android.view.View

--- a/app/src/main/java/app/envelop/ui/common/SystemBars.kt
+++ b/app/src/main/java/app/envelop/ui/common/SystemBars.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package app.envelop.ui.common
 
 import android.content.Context

--- a/app/src/main/java/app/envelop/ui/main/MainActivity.kt
+++ b/app/src/main/java/app/envelop/ui/main/MainActivity.kt
@@ -218,6 +218,7 @@ class MainActivity : BaseActivity() {
       .show()
   }
 
+  @Suppress("DEPRECATION")
   private fun openFileIntent() {
     startActivityForResult(
       Intent(Intent.ACTION_GET_CONTENT).apply {

--- a/app/src/test/java/app/envelop/common/rx/RxSingleToOperationKtTest.kt
+++ b/app/src/test/java/app/envelop/common/rx/RxSingleToOperationKtTest.kt
@@ -54,6 +54,4 @@ class RxSingleToOperationKtTest {
     )
   }
 
-
-
 }

--- a/app/src/test/java/app/envelop/common/rx/RxSingleToOperationKtTest.kt
+++ b/app/src/test/java/app/envelop/common/rx/RxSingleToOperationKtTest.kt
@@ -40,7 +40,6 @@ class RxSingleToOperationKtTest {
 
   @Test
   fun rxSingleOperationErrorExceptionSubscribed() {
-
     val exception = SocketTimeoutException()
     val stream = rxSingleToOperation {
       throw exception
@@ -53,5 +52,5 @@ class RxSingleToOperationKtTest {
       result
     )
   }
-
+  
 }

--- a/app/src/test/java/app/envelop/common/rx/RxSingleToOperationKtTest.kt
+++ b/app/src/test/java/app/envelop/common/rx/RxSingleToOperationKtTest.kt
@@ -52,5 +52,5 @@ class RxSingleToOperationKtTest {
       result
     )
   }
-  
+
 }

--- a/app/src/test/java/app/envelop/common/rx/RxSingleToOperationKtTest.kt
+++ b/app/src/test/java/app/envelop/common/rx/RxSingleToOperationKtTest.kt
@@ -1,0 +1,59 @@
+package app.envelop.common.rx
+
+
+import app.envelop.common.Operation
+import app.envelop.common.Optional
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.lang.Exception
+import java.net.SocketTimeoutException
+
+class RxSingleToOperationKtTest {
+
+  @Test
+  fun rxSingleOperationSuccess() {
+    val stream = rxSingleToOperation {
+      Optional.None
+    }
+
+    val result = stream.blockingGet()
+
+    assertEquals(
+      Operation.success(Optional.None),
+      result
+    )
+  }
+
+  @Test
+  fun rxSingleOperationSuccessValue() {
+    val stream = rxSingleToOperation {
+      Optional.create(true)
+    }
+
+    val result = stream.blockingGet()
+
+    assertEquals(
+      Operation.success(Optional.Some(true)),
+      result
+    )
+  }
+
+  @Test
+  fun rxSingleOperationErrorExceptionSubscribed() {
+
+    val exception = SocketTimeoutException()
+    val stream = rxSingleToOperation {
+      throw exception
+    }
+
+    val result = stream.blockingGet()
+
+    assertEquals(
+      Operation.error<Exception>(exception),
+      result
+    )
+  }
+
+
+
+}

--- a/app/src/test/java/app/envelop/data/repositories/RemoteRepositoryTest.kt
+++ b/app/src/test/java/app/envelop/data/repositories/RemoteRepositoryTest.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.launch
 import org.blockstack.android.sdk.BlockstackSession
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import java.net.SocketTimeoutException
 import javax.inject.Provider
 
 class RemoteRepositoryTest {
@@ -18,19 +17,17 @@ class RemoteRepositoryTest {
     @Test
     fun exceptionHandling() {
       val blockStackSessionMock = mock<BlockstackSession>()
-      val exception = SocketTimeoutException()
+      val exception = RuntimeException()
 
       GlobalScope.launch {
-        whenever(blockStackSessionMock.getFile(any(), any())).then {
-          throw exception
-        }
+        whenever(blockStackSessionMock.getFile(any(), any())).thenThrow(exception)
       }
 
       val remoteRepo = RemoteRepository(Provider { blockStackSessionMock }, Gson())
-      val result = remoteRepo.getJson("index", this::class, true).blockingGet()
+      val result = remoteRepo.getJson("index", Unit::class, true).blockingGet()
 
       assertEquals(
-        Operation.error<Exception>(exception),
+        Operation.error<RemoteRepository>(exception),
         result
       )
     }

--- a/app/src/test/java/app/envelop/data/repositories/RemoteRepositoryTest.kt
+++ b/app/src/test/java/app/envelop/data/repositories/RemoteRepositoryTest.kt
@@ -1,0 +1,37 @@
+package app.envelop.data.repositories
+
+import app.envelop.common.Operation
+import com.google.gson.Gson
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import org.blockstack.android.sdk.BlockstackSession
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.net.SocketTimeoutException
+import javax.inject.Provider
+
+class RemoteRepositoryTest {
+
+    @Test
+    fun exceptionHandling() {
+      val blockStackSessionMock = mock<BlockstackSession>()
+      val exception = SocketTimeoutException()
+
+      GlobalScope.launch {
+        whenever(blockStackSessionMock.getFile(any(), any())).then {
+          throw exception
+        }
+      }
+
+      val remoteRepo = RemoteRepository(Provider { blockStackSessionMock }, Gson())
+      val result = remoteRepo.getJson("index", this::class, true).blockingGet()
+
+      assertEquals(
+        Operation.error<Exception>(exception),
+        result
+      )
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-  ext.kotlin_version = '1.3.61'
+  ext.kotlin_version = '1.3.72'
   repositories {
     google()
     jcenter()
 
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.5.3'
+    classpath 'com.android.tools.build:gradle:3.5.4'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
   }
 }


### PR DESCRIPTION
Exceptions such as SocketTimeoutException could be triggered after RxSingle was no longer subscribed,
RxSingleToOperation avoids such exceptions from propagating by wrapping the exception in Error Or discarting if in background.