### PR TITLE
Issue with Mockito Dependencies 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -118,11 +118,15 @@ dependencies {
   testImplementation 'junit:junit:4.13'
   testImplementation 'org.mockito:mockito-inline:3.5.10'
   testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
-  androidTestImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
   androidTestImplementation 'androidx.test:runner:1.3.0'
   androidTestImplementation 'androidx.test:rules:1.3.0'
   androidTestImplementation 'androidx.test.ext:junit:1.1.2'
   androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
   androidTestImplementation 'androidx.test.espresso:espresso-intents:3.3.0'
-  androidTestImplementation 'org.mockito:mockito-android:3.4.6' //3.5 has an issue (lint.xml)
+  androidTestImplementation 'org.mockito:mockito-android:3.5.10'
+  androidTestImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0") {
+    // Workaround for Android API < 26:
+    // https://github.com/mockito/mockito/pull/2024
+    exclude group: "org.mockito", module: "mockito-core"
+  }
 }

--- a/app/lint.xml
+++ b/app/lint.xml
@@ -1,13 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lint>
 
-    <issue id="GradleDependency">
-        <ignore regexp="newer version of org.mockito:mockito-android than 3.4.6 is available: .*" />
-    </issue>
-    <issue id="NewerVersionAvailable">
-        <ignore regexp="newer version of org.mockito:mockito-android than 3.4.6 is available: .*" />
-    </issue>
-
     <issue id="CheckResult" severity="informational" />
     <issue id="AppLinksAutoVerifyWarning" severity="informational" />
     <issue id="GoogleAppIndexingApiWarning" severity="informational" />


### PR DESCRIPTION
Workaround for Android API < 26 with Gradle mergeExtDex 
https://github.com/mockito/mockito/pull/2024